### PR TITLE
Add canonical transform data for photobook slots

### DIFF
--- a/app/Services/PhotoBookBuilder.php
+++ b/app/Services/PhotoBookBuilder.php
@@ -437,11 +437,15 @@ class PhotoBookBuilder
         }
 
         // After we have $map and before rendering HTML, compute per-slot images
+        $targetDpi = (int) ($options['target_dpi'] ?? config('photobook.optimize.target_dpi', 160));
+        $targetDpi = max(120, min(220, $targetDpi));
         [$pagePxW, $pagePxH] = $this->pagePixels(
             $options['paper'] ?? config('photobook.paper'),
             $options['orientation'] ?? config('photobook.orientation', 'landscape'),
-            (int) ($options['target_dpi'] ?? config('photobook.optimize.target_dpi', 160))
+            $targetDpi
         );
+        $gapMm = (float) ($options['page_gap_mm'] ?? config('photobook.page_gap_mm', 2.5));
+        $gapPx = max(0, (int) round($gapMm / 25.4 * $targetDpi));
         $opt = config('photobook.optimize', []);
         $focalCache = [];
         $cntFaces = 0;
@@ -494,9 +498,12 @@ class PhotoBookBuilder
 
                 $targetW = max(1, (int) round(($s['w'] ?? 1.0) * $pagePxW));
                 $targetH = max(1, (int) round(($s['h'] ?? 1.0) * $pagePxH));
+                $contentW = max(1, $targetW - $gapPx);
+                $contentH = max(1, $targetH - $gapPx);
 
                 $ext = strtolower(pathinfo($origLocal, PATHINFO_EXTENSION) ?: 'jpg');
                 $slotLocal = $this->buildSlotRender($origLocal, $ext, $targetW, $targetH, $opt);
+                [$renderW, $renderH] = @getimagesize($slotLocal) ?: [0, 0];
 
                 // file:/// for Dompdf
                 $file = realpath($slotLocal) ?: $slotLocal;
@@ -571,8 +578,8 @@ class PhotoBookBuilder
                     if (isset($ovI['objectPosition']) && !isset($ovI['align'])) {
                         $align = $this->posToAlignLegacy(
                             (string) $ovI['objectPosition'],
-                            $targetW,
-                            $targetH,
+                            $contentW,
+                            $contentH,
                             $iw,
                             $ih,
                             $fit,
@@ -612,12 +619,12 @@ class PhotoBookBuilder
                                 });
                                 $cx = max(0.0, min(1.0, (float) ($feat['faces'][0]['cx'] ?? 0.5)));
                                 $cy = max(0.0, min(1.0, (float) ($feat['faces'][0]['cy'] ?? 0.5)));
-                                $align = $this->focusToAlign($cx, $cy, $targetW, $targetH, $iw, $ih, $fit, $zoom);
+                                $align = $this->focusToAlign($cx, $cy, $contentW, $contentH, $iw, $ih, $fit, $zoom);
                                 $cntFaces++;
                             } elseif (!empty($feat['saliency']) && is_array($feat['saliency'])) {
                                 $cx = max(0.0, min(1.0, (float) ($feat['saliency']['cx'] ?? 0.5)));
                                 $cy = max(0.0, min(1.0, (float) ($feat['saliency']['cy'] ?? 0.5)));
-                                $align = $this->focusToAlign($cx, $cy, $targetW, $targetH, $iw, $ih, $fit, $zoom);
+                                $align = $this->focusToAlign($cx, $cy, $contentW, $contentH, $iw, $ih, $fit, $zoom);
                                 $cntSaliency++;
                             }
                         } else {
@@ -630,12 +637,12 @@ class PhotoBookBuilder
                                 });
                                 $cx = max(0.0, min(1.0, (float) ($faces[0]['cx'] ?? 0.5)));
                                 $cy = max(0.0, min(1.0, (float) ($faces[0]['cy'] ?? 0.5)));
-                                $align = $this->focusToAlign($cx, $cy, $targetW, $targetH, $iw, $ih, $fit, $zoom);
+                                $align = $this->focusToAlign($cx, $cy, $contentW, $contentH, $iw, $ih, $fit, $zoom);
                                 $cntFaces++;
                             } elseif (!empty($feat->saliency) && is_array($feat->saliency)) {
                                 $cx = max(0.0, min(1.0, (float) ($feat->saliency['cx'] ?? 0.5)));
                                 $cy = max(0.0, min(1.0, (float) ($feat->saliency['cy'] ?? 0.5)));
-                                $align = $this->focusToAlign($cx, $cy, $targetW, $targetH, $iw, $ih, $fit, $zoom);
+                                $align = $this->focusToAlign($cx, $cy, $contentW, $contentH, $iw, $ih, $fit, $zoom);
                                 $cntSaliency++;
                             }
                         }
@@ -645,7 +652,7 @@ class PhotoBookBuilder
                     if ($auto && !$align) {
                         $hasPlannerPos = isset($it['objectPosition']) && trim((string) $it['objectPosition']) !== '' && trim((string) $it['objectPosition']) !== '50% 50%';
                         if ($hasPlannerPos) {
-                            $align = $this->posToAlignLegacy((string) $it['objectPosition'], $targetW, $targetH, $iw, $ih, $fit, $zoom);
+                            $align = $this->posToAlignLegacy((string) $it['objectPosition'], $contentW, $contentH, $iw, $ih, $fit, $zoom);
                         }
                     }
 
@@ -655,7 +662,7 @@ class PhotoBookBuilder
                             $focalCache[$origLocal] = $this->detectFocalPointForFile($origLocal); // [fx,fy] 0..1
                         }
                         [$fx, $fy] = $focalCache[$origLocal];
-                        $align = $this->focusToAlign((float) $fx, (float) $fy, $targetW, $targetH, $iw, $ih, $fit, $zoom);
+                        $align = $this->focusToAlign((float) $fx, (float) $fy, $contentW, $contentH, $iw, $ih, $fit, $zoom);
                         $cntFallback++;
                     }
                 }
@@ -672,6 +679,26 @@ class PhotoBookBuilder
                 $it['zoom'] = $zoom;
                 $it['rotation'] = $rotation;
                 $it['auto'] = $auto;
+
+                $transform = $this->computeItemTransform(
+                    $targetW,
+                    $targetH,
+                    $contentW,
+                    $contentH,
+                    $gapPx,
+                    $iw,
+                    $ih,
+                    $renderW ?? 0,
+                    $renderH ?? 0,
+                    $align,
+                    $offset,
+                    $fit,
+                    $zoom,
+                    $rotation
+                );
+                if ($transform) {
+                    $it['transform'] = $transform;
+                }
 
                 $items[] = $it;
             }
@@ -920,6 +947,75 @@ class PhotoBookBuilder
             'overflowX' => max(0.0, $fw - $slotW),
             'overflowY' => max(0.0, $fh - $slotH),
             'scale' => $scale,
+        ];
+    }
+
+    private function alignOffsetToPanPx(array $align, array $offset, float $overflowX, float $overflowY, int $slotW, int $slotH): array
+    {
+        $ax = is_array($align) ? floatval($align['x'] ?? 0.0) : 0.0;
+        $ay = is_array($align) ? floatval($align['y'] ?? 0.0) : 0.0;
+        $offX = is_array($offset) ? floatval($offset['x'] ?? 0.0) : 0.0;
+        $offY = is_array($offset) ? floatval($offset['y'] ?? 0.0) : 0.0;
+        $panX = ($overflowX / 2.0) * $ax + $offX * $slotW;
+        $panY = ($overflowY / 2.0) * $ay + $offY * $slotH;
+        return ['panX' => $panX, 'panY' => $panY];
+    }
+
+    private function computeItemTransform(
+        int $slotW,
+        int $slotH,
+        int $contentW,
+        int $contentH,
+        int $gapPx,
+        int $iw,
+        int $ih,
+        int $renderW,
+        int $renderH,
+        array $align,
+        array $offset,
+        string $fit,
+        float $zoom,
+        float $rotation
+    ): ?array {
+        if ($slotW <= 0 || $slotH <= 0 || $contentW <= 0 || $contentH <= 0 || $iw <= 0 || $ih <= 0) {
+            return null;
+        }
+        $math = $this->fitMath($contentW, $contentH, $iw, $ih, $fit, $zoom);
+        $pan = $this->alignOffsetToPanPx($align, $offset, $math['overflowX'], $math['overflowY'], $contentW, $contentH);
+
+        $imgW = ($renderW > 0) ? $renderW : $iw;
+        $imgH = ($renderH > 0) ? $renderH : $ih;
+        if ($imgW <= 0 || $imgH <= 0) {
+            return null;
+        }
+
+        $scale = $math['scale'];
+        if ($renderW > 0 && $iw > 0) {
+            $scale *= ($iw / max(1.0, (float) $renderW));
+        }
+        if (!is_finite($scale) || $scale <= 0) {
+            $scale = $math['scale'];
+        }
+
+        $panX = is_array($pan) ? floatval($pan['panX'] ?? 0.0) : 0.0;
+        $panY = is_array($pan) ? floatval($pan['panY'] ?? 0.0) : 0.0;
+
+        return [
+            'slotWidth' => $slotW,
+            'slotHeight' => $slotH,
+            'contentWidth' => $contentW,
+            'contentHeight' => $contentH,
+            'innerPad' => (int) floor(max(0.0, (float) $gapPx) / 2),
+            'imgWidth' => $imgW,
+            'imgHeight' => $imgH,
+            'scale' => round((float) $scale, 6),
+            'panX' => round($panX, 4),
+            'panY' => round($panY, 4),
+            'rotation' => round($rotation, 4),
+            'overflowX' => round((float) $math['overflowX'], 4),
+            'overflowY' => round((float) $math['overflowY'], 4),
+            'fit' => $fit,
+            'zoom' => round($zoom, 4),
         ];
     }
 

--- a/resources/views/photobook/generic.blade.php
+++ b/resources/views/photobook/generic.blade.php
@@ -9,6 +9,17 @@
   - Add optional per-item rotation support in Blade if we later export rotated slot renders (currently rotation handled in UI only).
 --}}
 {{-- $slots: array of rects; $items: [{photo, slotIndex, crop, objectPosition, src, caption}] --}}
+@php
+  $formatNumber = static function ($value, int $precision = 4): string {
+      $num = round((float) $value, $precision);
+      $str = number_format($num, $precision, '.', '');
+      $str = rtrim(rtrim($str, '0'), '.');
+      if ($str === '' || $str === '-0') {
+          $str = '0';
+      }
+      return $str;
+  };
+@endphp
 <div class="page">
   <div class="page-inner">
     @foreach($items as $it)
@@ -30,11 +41,44 @@
           } elseif (is_array($p)) {
             $label = $p['filename'] ?? (isset($p['path']) ? basename($p['path']) : '');
           }
+          $transform = is_array($it['transform'] ?? null) ? $it['transform'] : null;
+          $hasTransform = $transform && ($transform['imgWidth'] ?? 0) > 0 && ($transform['imgHeight'] ?? 0) > 0 && $src;
         @endphp
-  <div class="img"
-             aria-label="{{ $label }}"
-             style="background-image:url('{{ $src }}'); background-position: {{ $it['objectPosition'] ?? '50% 50%' }};">
-        </div>
+
+        @if($hasTransform)
+          @php
+            $imgW = max(0, (int) round($transform['imgWidth']));
+            $imgH = max(0, (int) round($transform['imgHeight']));
+            if ($imgW <= 0 || $imgH <= 0) {
+              $hasTransform = false;
+            }
+          @endphp
+        @endif
+
+        @if($hasTransform)
+          @php
+            $panX = $formatNumber($transform['panX'] ?? 0, 3) . 'px';
+            $panY = $formatNumber($transform['panY'] ?? 0, 3) . 'px';
+            $scaleStr = $formatNumber($transform['scale'] ?? 1, 6);
+            $rotStr = $formatNumber($transform['rotation'] ?? 0, 4);
+            $transformCss = "translate(-50%, -50%) translate({$panX}, {$panY}) rotate({$rotStr}deg) scale({$scaleStr})";
+          @endphp
+          <div class="slot-inner">
+            <img src="{{ $src }}"
+                 alt=""
+                 aria-label="{{ $label }}"
+                 style="width: {{ $imgW }}px; height: {{ $imgH }}px; max-width:none; max-height:none; transform: {{ $transformCss }};">
+          </div>
+        @else
+          @php
+            $pos = $it['objectPosition'] ?? '50% 50%';
+            $fitMode = (($it['fit'] ?? ($it['crop'] ?? 'cover')) === 'contain') ? 'contain' : 'cover';
+          @endphp
+          <div class="slot-inner slot-inner-legacy"
+               aria-label="{{ $label }}"
+               style="background-image:url('{{ e($src) }}'); background-position: {{ $pos }}; background-size: {{ $fitMode }};">
+          </div>
+        @endif
         @if(!empty($it['caption']))
           <div class="caption">{{ $it['caption'] }}</div>
         @endif

--- a/resources/views/photobook/layout.blade.php
+++ b/resources/views/photobook/layout.blade.php
@@ -27,7 +27,9 @@ Create the main layout for the PDF:
   overflow:hidden;
 }
 .slot { position:absolute; overflow:hidden; box-sizing:border-box; background:#fff; }
-.slot > .img { width:100%; height:100%; background-size:cover; background-repeat:no-repeat; background-origin: content-box; }
+.slot-inner { position:relative; width:100%; height:100%; overflow:hidden; background:#fff; }
+.slot-inner img { position:absolute; left:50%; top:50%; max-width:none; max-height:none; transform-origin:center center; display:block; }
+.slot-inner-legacy { width:100%; height:100%; background-repeat:no-repeat; background-origin: content-box; }
 .caption { font-size: 10pt; margin-top: 2mm; }
 </style>
 </head>

--- a/resources/views/photobook/review.blade.php
+++ b/resources/views/photobook/review.blade.php
@@ -39,11 +39,34 @@
             overflow: hidden;
         }
 
-        .thumb>div {
+        .thumb-slot {
             position: absolute;
             inset: 0;
-            background-size: cover;
+            box-sizing: border-box;
+        }
+
+        .thumb-inner {
+            position: absolute;
+            inset: 0;
+            overflow: hidden;
+            background: #fff;
+        }
+
+        .thumb-inner img {
+            position: absolute;
+            left: 50%;
+            top: 50%;
+            max-width: none;
+            max-height: none;
+            transform-origin: center center;
+            display: block;
+        }
+
+        .thumb-fallback {
+            position: absolute;
+            inset: 0;
             background-position: center;
+            background-size: cover;
         }
 
         .controls {
@@ -89,6 +112,17 @@
     @if(empty($pages))
         <p class="small">No pages.json found. Build a book first.</p>
     @else
+    @php
+        $formatNumber = static function ($value, int $precision = 4): string {
+            $num = round((float) $value, $precision);
+            $str = number_format($num, $precision, '.', '');
+            $str = rtrim(rtrim($str, '0'), '.');
+            if ($str === '' || $str === '-0') {
+                $str = '0';
+            }
+            return $str;
+        };
+    @endphp
     @foreach($pages as $p)
     @php($n = (int) ($p['n'] ?? 0))
     @php($items = $p['items'] ?? [])
@@ -141,11 +175,48 @@
 
         <div class="grid" style="margin-top:8px;">
             @foreach($items as $it)
-            @php($pos = $it['objectPosition'] ?? '50% 50%')
-            @php($src = $it['webSrc'] ?? ($it['web'] ?? ($it['src'] ?? '')))
-            <div class="thumb">
-                @php($bg = "background-image:url('" . e($src) . "'); background-position: " . e($pos) . ";")
-                <div style="{{ $bg }}"></div>
+            @php
+                $pos = $it['objectPosition'] ?? '50% 50%';
+                $src = $it['webSrc'] ?? ($it['web'] ?? ($it['src'] ?? ''));
+                $transform = is_array($it['transform'] ?? null) ? $it['transform'] : null;
+                $hasTransform = $transform && ($transform['imgWidth'] ?? 0) > 0 && ($transform['imgHeight'] ?? 0) > 0 && $src;
+                $slotW = $hasTransform ? max(0.0, (float) ($transform['slotWidth'] ?? 0)) : 0.0;
+                $slotH = $hasTransform ? max(0.0, (float) ($transform['slotHeight'] ?? 0)) : 0.0;
+                $aspectPct = ($slotW > 0 && $slotH > 0) ? ($slotH / $slotW * 100.0) : 66.0;
+            @endphp
+            <div class="thumb" style="padding-top: {{ $formatNumber($aspectPct, 4) }}%;">
+                @if($hasTransform)
+                    @php
+                        $innerPad = max(0.0, (float) ($transform['innerPad'] ?? 0));
+                        $contentW = max(1e-6, (float) ($transform['contentWidth'] ?? 0));
+                        $contentH = max(1e-6, (float) ($transform['contentHeight'] ?? 0));
+                        $padX = ($slotW > 0) ? ($innerPad / $slotW * 100.0) : 0.0;
+                        $padY = ($slotH > 0) ? ($innerPad / $slotH * 100.0) : 0.0;
+                        $imgWPercent = ($transform['imgWidth'] ?? 0) / $contentW * 100.0;
+                        $imgHPercent = ($transform['imgHeight'] ?? 0) / $contentH * 100.0;
+                        $panXPercent = ($transform['panX'] ?? 0) / $contentW * 100.0;
+                        $panYPercent = ($transform['panY'] ?? 0) / $contentH * 100.0;
+                        $scaleStr = $formatNumber($transform['scale'] ?? 1, 6);
+                        $rotStr = $formatNumber($transform['rotation'] ?? 0, 4);
+                        $padXStr = $formatNumber($padX, 3) . '%';
+                        $padYStr = $formatNumber($padY, 3) . '%';
+                        $imgWStr = $formatNumber($imgWPercent, 4) . '%';
+                        $imgHStr = $formatNumber($imgHPercent, 4) . '%';
+                        $panXStr = $formatNumber($panXPercent, 3) . '%';
+                        $panYStr = $formatNumber($panYPercent, 3) . '%';
+                        $transformCss = "translate(-50%, -50%) translate({$panXStr}, {$panYStr}) rotate({$rotStr}deg) scale({$scaleStr})";
+                    @endphp
+                    <div class="thumb-slot" style="padding: {{ $padYStr }} {{ $padXStr }};">
+                        <div class="thumb-inner">
+                            <img src="{{ $src }}" alt="" style="width: {{ $imgWStr }}; height: {{ $imgHStr }}; max-width:none; max-height:none; transform: {{ $transformCss }};">
+                        </div>
+                    </div>
+                @else
+                    @php
+                        $fitMode = (($it['fit'] ?? ($it['crop'] ?? 'cover')) === 'contain') ? 'contain' : 'cover';
+                    @endphp
+                    <div class="thumb-fallback" style="background-image:url('{{ e($src) }}'); background-position: {{ $pos }}; background-size: {{ $fitMode }};"></div>
+                @endif
             </div>
             @endforeach
         </div>
@@ -158,7 +229,7 @@
         (function fixThumbUrls(){
             try {
                 const origin = location.origin;
-                document.querySelectorAll('.thumb > div').forEach((el)=>{
+                document.querySelectorAll('.thumb-fallback').forEach((el)=>{
                     const st = el.style.backgroundImage || '';
                     const m = st.match(/url\(["']?(.*?)["']?\)/);
                     if (m && m[1] && m[1].startsWith('/')) {


### PR DESCRIPTION
## Summary
- compute canonical pixel transforms for each photobook item in the builder and attach them to the page data
- switch the generic PDF layout to render slots with absolutely positioned images using the canonical transform values
- mirror the same transform-aware rendering for the review thumbnails so they match the editor output

## Testing
- php -l app/Services/PhotoBookBuilder.php
- vendor/bin/phpunit *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d071efd8b083229aaf1b9c30e6972f