### PR TITLE
Add caption editing and rendering for photobook slots

### DIFF
--- a/app/Services/PhotoBookBuilder.php
+++ b/app/Services/PhotoBookBuilder.php
@@ -877,6 +877,7 @@ class PhotoBookBuilder
                         // --- legacy (kept for compatibility)
                         'crop' => $it['crop'] ?? (($it['fit'] ?? 'cover') === 'contain' ? 'contain' : 'cover'),
                         'objectPosition' => $it['objectPosition'] ?? '50% 50%',
+                        'caption' => array_key_exists('caption', $it) ? $it['caption'] : null,
 
                         // --- canonical (UI + Python use these)
                         'fit' => $it['fit'] ?? 'cover',

--- a/resources/photobook-editor/src/App.tsx
+++ b/resources/photobook-editor/src/App.tsx
@@ -179,6 +179,12 @@ function Root() {
           ? Number(it.rotation)
           : (Number.isFinite(Number(it.rotate)) ? Number(it.rotate) : 0);
         const auto = !!it.auto;
+        const caption =
+          typeof it.caption === 'string'
+            ? it.caption
+            : typeof it.caption === 'number'
+              ? String(it.caption)
+              : undefined;
 
         // legacy (keep for back-compat)
         const objectPosition = `${Math.round(50 + align.x * 50)}% ${Math.round(50 + align.y * 50)}%`;
@@ -190,6 +196,7 @@ function Root() {
           fit, align, offset, zoom, rotation, auto,
           ...(it.photo?.path ? { photo: { path: it.photo.path, ...(it.photo.filename ? { filename: it.photo.filename } : {}) } } : {}),
           ...(it.src ? { src: it.src } : {}),
+          ...(caption !== undefined ? { caption } : {}),
 
           // --- legacy ---
           crop: fit,
@@ -458,6 +465,12 @@ function Root() {
                     const zoom = isPos(it.zoom) ? Number(it.zoom) : 1;
                     const rotation = Number.isFinite(Number(it.rotation)) ? Number(it.rotation) : 0;
                     const objectPosition = `${Math.round(50 + align.x * 50)}% ${Math.round(50 + align.y * 50)}%`;
+                    const caption =
+                      typeof it.caption === 'string'
+                        ? it.caption
+                        : typeof it.caption === 'number'
+                          ? String(it.caption)
+                          : undefined;
 
                     return {
                       slotIndex: it.slotIndex,
@@ -466,6 +479,7 @@ function Root() {
                       fit, align, offset, zoom, rotation, auto: !!it.auto,
                       ...(it.photo?.path ? { photo: { path: it.photo.path, ...(it.photo.filename ? { filename: it.photo.filename } : {}) } } : {}),
                       ...(it.src ? { src: it.src } : {}),
+                      ...(caption !== undefined ? { caption } : {}),
 
                       // legacy
                       crop: fit,
@@ -481,7 +495,13 @@ function Root() {
 
             />
           </div>
-          <Sidebar page={page} onSwap={swapItems} onReplace={openReplace} onTemplateChange={async (tpl) => {
+          <Sidebar page={page} onSwap={swapItems} onReplace={openReplace} onUpdateItem={(idx, changes) => {
+            if (!page) return;
+            const existing = page.items?.[idx];
+            if (!existing) return;
+            page.items[idx] = { ...existing, ...changes };
+            setPageVersion(v => v + 1);
+          }} onTemplateChange={async (tpl) => {
             if (!page) return;
             if (pageIdx === 0) return; // no template selection for cover
             // Apply slots from selected template immediately in UI

--- a/resources/photobook-editor/src/components/EditorCanvas.tsx
+++ b/resources/photobook-editor/src/components/EditorCanvas.tsx
@@ -94,6 +94,9 @@ type AnyItem = {
   scale?: number;
   rotate?: number;
 
+  // Metadata
+  caption?: string;
+
   // Runtime
   _iw?: number; _ih?: number; // natural size
   _error?: boolean;           // load error
@@ -166,7 +169,10 @@ function normalizeItem(it: AnyItem): AnyItem {
     // Rotation: prefer canonical, else legacy rotate
     rotation: Number.isFinite(it.rotation) ? (it.rotation as number) % 360
             : (Number.isFinite(it.rotate) ? (Number(it.rotate) % 360) : 0),
-    auto: it.auto === true ? true : false
+    auto: it.auto === true ? true : false,
+    caption: typeof it.caption === 'string'
+      ? it.caption
+      : (typeof (it as any).caption === 'number' ? String((it as any).caption) : undefined),
   };
 }
 
@@ -198,12 +204,19 @@ function buildOverridesPayload(
       const offset = { x: Number(it.offset?.x) || 0, y: Number(it.offset?.y) || 0 };
       const zoom = isFinitePos(it.zoom) ? Number(it.zoom) : 1;
       const rotation = Number.isFinite(Number(it.rotation)) ? ((Number(it.rotation) % 360) + 360) % 360 : 0;
+      const caption =
+        typeof it.caption === 'string'
+          ? it.caption
+          : typeof (it as any).caption === 'number'
+            ? String((it as any).caption)
+            : undefined;
 
       const canon = {
         slotIndex: it.slotIndex,
         fit, align, offset, zoom, rotation,
         auto: it.auto === true,
         ...(it.photo?.path ? { photo: { path: it.photo.path, ...(it.photo.filename ? { filename: it.photo.filename } : {}) } } : {}),
+        ...(caption !== undefined ? { caption } : {}),
       };
 
       const legacy = {

--- a/resources/photobook-editor/src/components/Sidebar.tsx
+++ b/resources/photobook-editor/src/components/Sidebar.tsx
@@ -6,9 +6,15 @@ import React from 'react';
 import { useSelection } from '../state/selection';
 import { useTemplates } from '../hooks/useTemplates';
 import type { LayoutTemplate } from '../api/types';
-type Props = { page: any; onSwap: (a:number,b:number)=>void; onReplace:(i:number)=>void; onTemplateChange:(id:string)=>void };
+type Props = {
+  page: any;
+  onSwap: (a:number,b:number)=>void;
+  onReplace:(i:number)=>void;
+  onTemplateChange:(id:string)=>void;
+  onUpdateItem: (idx:number, changes:Record<string, any>) => void;
+};
 
-export default function Sidebar({ page, onSwap, onReplace, onTemplateChange }: Props) {
+export default function Sidebar({ page, onSwap, onReplace, onTemplateChange, onUpdateItem }: Props) {
   const { setSelected } = useSelection();
    const templatesQ = useTemplates();
   const templateGroups = React.useMemo(() => {
@@ -64,17 +70,26 @@ export default function Sidebar({ page, onSwap, onReplace, onTemplateChange }: P
         <div className="text-sm font-medium">Items</div>
         <ul className="mt-2 flex flex-col gap-2">
           {page.items.map((it: any, i: number)=>(
-            <li key={i} className="flex items-center gap-2">
-              <div className="w-12 h-10 bg-neutral-100 rounded overflow-hidden">
-                {(() => { const u = (it as any).webSrc || (it as any).web || it.src; return u ? <img src={u} alt="thumb" className="w-full h-full object-cover"/> : null; })()}
+            <li key={i} className="flex flex-col gap-2 p-2 border border-neutral-200 rounded">
+              <div className="flex items-center gap-2">
+                <div className="w-12 h-10 bg-neutral-100 rounded overflow-hidden">
+                  {(() => { const u = (it as any).webSrc || (it as any).web || it.src; return u ? <img src={u} alt="thumb" className="w-full h-full object-cover"/> : null; })()}
+                </div>
+                <div className="text-xs flex-1">
+                  <div>slot {it.slotIndex}</div>
+                  <div className="text-neutral-500">{it.photo?.filename || '—'}</div>
+                </div>
+                <button className="text-xs px-2 py-1 bg-neutral-200 rounded" onClick={()=>{ setSelected(`${page.n}:${i}`); onReplace(i); }}>Replace</button>
+                {i>0 && <button className="text-xs px-2 py-1 bg-neutral-800 text-white rounded" onClick={()=>onSwap(i,i-1)}>↑</button>}
+                {i<page.items.length-1 && <button className="text-xs px-2 py-1 bg-neutral-800 text-white rounded" onClick={()=>onSwap(i,i+1)}>↓</button>}
               </div>
-              <div className="text-xs flex-1">
-                <div>slot {it.slotIndex}</div>
-                <div className="text-neutral-500">{it.photo?.filename || '—'}</div>
-              </div>
-              <button className="text-xs px-2 py-1 bg-neutral-200 rounded" onClick={()=>{ setSelected(`${page.n}:${i}`); onReplace(i); }}>Replace</button>
-              {i>0 && <button className="text-xs px-2 py-1 bg-neutral-800 text-white rounded" onClick={()=>onSwap(i,i-1)}>↑</button>}
-              {i<page.items.length-1 && <button className="text-xs px-2 py-1 bg-neutral-800 text-white rounded" onClick={()=>onSwap(i,i+1)}>↓</button>}
+              <input
+                type="text"
+                value={typeof it.caption === 'string' ? it.caption : ''}
+                onChange={(e) => onUpdateItem(i, { caption: e.target.value })}
+                className="w-full border border-neutral-200 rounded px-2 py-1 text-xs"
+                placeholder="Caption (emoji ok)"
+              />
             </li>
           ))}
         </ul>

--- a/resources/photobook-editor/src/components/SlotView.tsx
+++ b/resources/photobook-editor/src/components/SlotView.tsx
@@ -24,6 +24,7 @@ export type Item = {
   _iw?: number;
   _ih?: number;
   _error?: boolean;
+  caption?: string;
 };
 
 export type SlotSnapshot = {
@@ -87,6 +88,13 @@ export default function SlotView({
 
   const src = getSrc(item);
   const loaded = iw > 0 && ih > 0;
+  const captionRaw =
+    typeof item.caption === 'string'
+      ? item.caption
+      : typeof (item as any).caption === 'number'
+        ? String((item as any).caption)
+        : '';
+  const hasCaption = captionRaw.trim().length > 0;
 
   return (
     <div
@@ -230,6 +238,30 @@ export default function SlotView({
         ) : (
           <div className="w-full h-full grid place-items-center bg-neutral-100 text-neutral-500 text-xs">
             {item._error ? 'Bild konnte nicht geladen werden' : 'Kein Bild'}
+          </div>
+        )}
+        {hasCaption && (
+          <div
+            style={{
+              position: 'absolute',
+              left: innerPad + 6,
+              right: innerPad + 6,
+              bottom: innerPad + 6,
+              background: 'rgba(255,255,255,0.92)',
+              color: '#1f2937',
+              fontSize: '11px',
+              lineHeight: 1.3,
+              padding: '6px 8px',
+              borderRadius: '6px',
+              textAlign: 'center',
+              wordBreak: 'break-word',
+              whiteSpace: 'pre-wrap',
+              pointerEvents: 'none',
+              boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+              zIndex: 3,
+            }}
+          >
+            {captionRaw}
           </div>
         )}
       </div>

--- a/resources/views/photobook/generic.blade.php
+++ b/resources/views/photobook/generic.blade.php
@@ -43,6 +43,14 @@
           }
           $transform = is_array($it['transform'] ?? null) ? $it['transform'] : null;
           $hasTransform = $transform && ($transform['imgWidth'] ?? 0) > 0 && ($transform['imgHeight'] ?? 0) > 0 && $src;
+          $captionRaw = '';
+          if (array_key_exists('caption', $it)) {
+            $val = $it['caption'];
+            if (is_string($val) || is_numeric($val)) {
+              $captionRaw = (string) $val;
+            }
+          }
+          $caption = trim($captionRaw) !== '' ? $captionRaw : '';
         @endphp
 
         @if($hasTransform)
@@ -79,8 +87,8 @@
                style="background-image:url('{{ e($src) }}'); background-position: {{ $pos }}; background-size: {{ $fitMode }};">
           </div>
         @endif
-        @if(!empty($it['caption']))
-          <div class="caption">{{ $it['caption'] }}</div>
+        @if($caption !== '')
+          <div class="caption">{{ $caption }}</div>
         @endif
       </div>
     @endforeach

--- a/resources/views/photobook/layout.blade.php
+++ b/resources/views/photobook/layout.blade.php
@@ -30,7 +30,23 @@ Create the main layout for the PDF:
 .slot-inner { position:relative; width:100%; height:100%; overflow:hidden; background:#fff; }
 .slot-inner img { position:absolute; left:50%; top:50%; max-width:none; max-height:none; transform-origin:center center; display:block; }
 .slot-inner-legacy { width:100%; height:100%; background-repeat:no-repeat; background-origin: content-box; }
-.caption { font-size: 10pt; margin-top: 2mm; }
+.caption {
+  position:absolute;
+  left: calc(var(--gap-mm) / 2);
+  right: calc(var(--gap-mm) / 2);
+  bottom: calc(var(--gap-mm) / 2);
+  font-size: 10pt;
+  line-height: 1.25;
+  padding: 1.4mm 1.8mm;
+  background: rgba(255, 255, 255, 0.88);
+  color: #1f2937;
+  border-radius: 1.2mm;
+  text-align: center;
+  word-break: break-word;
+  pointer-events: none;
+  box-shadow: 0 0.6mm 2.4mm rgba(0, 0, 0, 0.12);
+  z-index: 3;
+}
 </style>
 </head>
 <body>

--- a/resources/views/photobook/page-1up.blade.php
+++ b/resources/views/photobook/page-1up.blade.php
@@ -5,9 +5,18 @@
         $src = $asset_url($photos[0]);
         $p = $photos[0] ?? null;
         $label = is_object($p) ? ($p->filename ?? basename($p->path ?? '')) : (is_array($p) ? ($p['filename'] ?? basename($p['path'] ?? '')) : '');
+        $caption = '';
+        if (is_object($p) && isset($p->caption)) {
+          $caption = (string) $p->caption;
+        } elseif (is_array($p) && array_key_exists('caption', $p)) {
+          $caption = (string) $p['caption'];
+        }
       @endphp
-      <div class="img" aria-label="{{ $label }}"
-           style="background-image:url('{{ $src }}'); background-position:center center;"></div>
+      <div class="slot-inner slot-inner-legacy" aria-label="{{ $label }}"
+           style="background-image:url('{{ $src }}'); background-position:center center; background-size:cover;"></div>
+      @if(trim($caption) !== '')
+        <div class="caption">{{ $caption }}</div>
+      @endif
     </div>
   </div>
 </div>

--- a/resources/views/photobook/page-2up.blade.php
+++ b/resources/views/photobook/page-2up.blade.php
@@ -13,9 +13,18 @@
         $src = $asset_url($photos[0]);
         $p = $photos[0] ?? null;
         $label = is_object($p) ? ($p->filename ?? basename($p->path ?? '')) : (is_array($p) ? ($p['filename'] ?? basename($p['path'] ?? '')) : '');
+        $caption = '';
+        if (is_object($p) && isset($p->caption)) {
+          $caption = (string) $p->caption;
+        } elseif (is_array($p) && array_key_exists('caption', $p)) {
+          $caption = (string) $p['caption'];
+        }
       @endphp
-      <div class="img" aria-label="{{ $label }}"
-           style="background-image:url('{{ $src }}'); background-position:center center;"></div>
+      <div class="slot-inner slot-inner-legacy" aria-label="{{ $label }}"
+           style="background-image:url('{{ $src }}'); background-position:center center; background-size:cover;"></div>
+      @if(trim($caption) !== '')
+        <div class="caption">{{ $caption }}</div>
+      @endif
     </div>
 
     {{-- right column --}}
@@ -31,9 +40,18 @@
         $src = $asset_url($photos[1]);
         $p = $photos[1] ?? null;
         $label = is_object($p) ? ($p->filename ?? basename($p->path ?? '')) : (is_array($p) ? ($p['filename'] ?? basename($p['path'] ?? '')) : '');
+        $caption = '';
+        if (is_object($p) && isset($p->caption)) {
+          $caption = (string) $p->caption;
+        } elseif (is_array($p) && array_key_exists('caption', $p)) {
+          $caption = (string) $p['caption'];
+        }
       @endphp
-      <div class="img" aria-label="{{ $label }}"
-           style="background-image:url('{{ $src }}'); background-position:center center;"></div>
+      <div class="slot-inner slot-inner-legacy" aria-label="{{ $label }}"
+           style="background-image:url('{{ $src }}'); background-position:center center; background-size:cover;"></div>
+      @if(trim($caption) !== '')
+        <div class="caption">{{ $caption }}</div>
+      @endif
     </div>
   </div>
 </div>

--- a/resources/views/photobook/page-3up.blade.php
+++ b/resources/views/photobook/page-3up.blade.php
@@ -13,9 +13,18 @@
         $src = $asset_url($photos[0]);
         $p = $photos[0] ?? null;
         $label = is_object($p) ? ($p->filename ?? basename($p->path ?? '')) : (is_array($p) ? ($p['filename'] ?? basename($p['path'] ?? '')) : '');
+        $caption = '';
+        if (is_object($p) && isset($p->caption)) {
+          $caption = (string) $p->caption;
+        } elseif (is_array($p) && array_key_exists('caption', $p)) {
+          $caption = (string) $p['caption'];
+        }
       @endphp
-      <div class="img" aria-label="{{ $label }}"
-           style="background-image:url('{{ $src }}'); background-position:center center;"></div>
+      <div class="slot-inner slot-inner-legacy" aria-label="{{ $label }}"
+           style="background-image:url('{{ $src }}'); background-position:center center; background-size:cover;"></div>
+      @if(trim($caption) !== '')
+        <div class="caption">{{ $caption }}</div>
+      @endif
     </div>
 
     {{-- col 2 --}}
@@ -31,9 +40,18 @@
         $src = $asset_url($photos[1]);
         $p = $photos[1] ?? null;
         $label = is_object($p) ? ($p->filename ?? basename($p->path ?? '')) : (is_array($p) ? ($p['filename'] ?? basename($p['path'] ?? '')) : '');
+        $caption = '';
+        if (is_object($p) && isset($p->caption)) {
+          $caption = (string) $p->caption;
+        } elseif (is_array($p) && array_key_exists('caption', $p)) {
+          $caption = (string) $p['caption'];
+        }
       @endphp
-      <div class="img" aria-label="{{ $label }}"
-           style="background-image:url('{{ $src }}'); background-position:center center;"></div>
+      <div class="slot-inner slot-inner-legacy" aria-label="{{ $label }}"
+           style="background-image:url('{{ $src }}'); background-position:center center; background-size:cover;"></div>
+      @if(trim($caption) !== '')
+        <div class="caption">{{ $caption }}</div>
+      @endif
     </div>
 
     {{-- col 3 --}}
@@ -49,9 +67,18 @@
         $src = $asset_url($photos[2]);
         $p = $photos[2] ?? null;
         $label = is_object($p) ? ($p->filename ?? basename($p->path ?? '')) : (is_array($p) ? ($p['filename'] ?? basename($p['path'] ?? '')) : '');
+        $caption = '';
+        if (is_object($p) && isset($p->caption)) {
+          $caption = (string) $p->caption;
+        } elseif (is_array($p) && array_key_exists('caption', $p)) {
+          $caption = (string) $p['caption'];
+        }
       @endphp
-      <div class="img" aria-label="{{ $label }}"
-           style="background-image:url('{{ $src }}'); background-position:center center;"></div>
+      <div class="slot-inner slot-inner-legacy" aria-label="{{ $label }}"
+           style="background-image:url('{{ $src }}'); background-position:center center; background-size:cover;"></div>
+      @if(trim($caption) !== '')
+        <div class="caption">{{ $caption }}</div>
+      @endif
     </div>
   </div>
 </div>

--- a/resources/views/photobook/review.blade.php
+++ b/resources/views/photobook/review.blade.php
@@ -45,6 +45,23 @@
             box-sizing: border-box;
         }
 
+        .thumb-caption {
+            position: absolute;
+            left: 6px;
+            right: 6px;
+            bottom: 6px;
+            padding: 6px 8px;
+            background: rgba(255, 255, 255, 0.9);
+            color: #1f2937;
+            font-size: 12px;
+            line-height: 1.3;
+            text-align: center;
+            border-radius: 6px;
+            word-break: break-word;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            pointer-events: none;
+        }
+
         .thumb-inner {
             position: absolute;
             inset: 0;
@@ -183,6 +200,9 @@
                 $slotW = $hasTransform ? max(0.0, (float) ($transform['slotWidth'] ?? 0)) : 0.0;
                 $slotH = $hasTransform ? max(0.0, (float) ($transform['slotHeight'] ?? 0)) : 0.0;
                 $aspectPct = ($slotW > 0 && $slotH > 0) ? ($slotH / $slotW * 100.0) : 66.0;
+                $captionRaw = $it['caption'] ?? null;
+                $captionText = is_string($captionRaw) ? $captionRaw : (is_numeric($captionRaw) ? (string) $captionRaw : '');
+                $captionDisplay = trim((string) $captionText) !== '' ? $captionText : '';
             @endphp
             <div class="thumb" style="padding-top: {{ $formatNumber($aspectPct, 4) }}%;">
                 @if($hasTransform)
@@ -216,6 +236,9 @@
                         $fitMode = (($it['fit'] ?? ($it['crop'] ?? 'cover')) === 'contain') ? 'contain' : 'cover';
                     @endphp
                     <div class="thumb-fallback" style="background-image:url('{{ e($src) }}'); background-position: {{ $pos }}; background-size: {{ $fitMode }};"></div>
+                @endif
+                @if($captionDisplay !== '')
+                    <div class="thumb-caption">{{ $captionDisplay }}</div>
                 @endif
             </div>
             @endforeach


### PR DESCRIPTION
## Summary
- keep per-item captions when exporting pages from the PHP photobook builder
- render caption overlays across PDF/review templates, including legacy 1-up/2-up/3-up pages
- let the React editor preview, edit, and persist captions with dedicated sidebar inputs and slot overlays

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d06f4cab48832286959201ddaa3b80