### PR TITLE
Fix docker compose node setup and preserve cached cover paths

### DIFF
--- a/.devcontainer/ensure-node.sh
+++ b/.devcontainer/ensure-node.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v node >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+  exit 0
+fi
+
+echo "[ensure-node] Installing Node.js 20"
+if ! command -v curl >/dev/null 2>&1; then
+  echo "[ensure-node] curl not found, installing"
+  sudo apt-get update -y
+  sudo apt-get install -y curl
+fi
+
+# Install Node.js 20 from NodeSource if node is missing
+if ! command -v node >/dev/null 2>&1; then
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+if command -v corepack >/dev/null 2>&1; then
+  sudo corepack enable || true
+fi
+
+node --version
+npm --version

--- a/app/Http/Controllers/PhotobookApiController.php
+++ b/app/Http/Controllers/PhotobookApiController.php
@@ -27,6 +27,16 @@ class PhotobookApiController extends Controller
 
     private function normalizeAssetUrl(string $hash, $value): ?string
     {
+        $relative = $this->extractRelativeAssetPath($hash, $value);
+        if ($relative) {
+            return route('photobook.asset', ['hash' => $hash, 'path' => $relative], false);
+        }
+
+        return null;
+    }
+
+    private function extractRelativeAssetPath(string $hash, $value): ?string
+    {
         if (!is_string($value) || $value === '') {
             return null;
         }
@@ -46,21 +56,39 @@ class PhotobookApiController extends Controller
             }
 
             $trimmed = preg_split('/[?#]/', $path, 2)[0] ?? $path;
-            $withLeadingSlash = $trimmed !== '' && $trimmed[0] !== '/' ? '/' . $trimmed : $trimmed;
+            if ($trimmed === '') {
+                continue;
+            }
 
-            if ($withLeadingSlash !== '' && preg_match('#/photobook/asset/' . preg_quote($hash, '#') . '/(.+)$#', $withLeadingSlash, $m)) {
-                $rel = ltrim($m[1], '/');
-                if ($rel !== '') {
-                    return route('photobook.asset', ['hash' => $hash, 'path' => $rel], false);
+            $candidates = [$trimmed];
+            if ($trimmed[0] !== '/') {
+                $candidates[] = '/' . $trimmed;
+            }
+
+            foreach ($candidates as $candidatePath) {
+                if ($candidatePath !== '' && preg_match('#/photobook/asset/' . preg_quote($hash, '#') . '/(.+)$#', $candidatePath, $m)) {
+                    $rel = ltrim($m[1], '/');
+                    if ($rel !== '') {
+                        return $rel;
+                    }
                 }
             }
 
-            $needle = '/_cache/' . $hash . '/';
-            $pos = strpos($trimmed, $needle);
-            if ($pos !== false) {
-                $rel = ltrim(substr($trimmed, $pos + strlen($needle)), '/');
+            foreach ($candidates as $candidatePath) {
+                $needle = '/_cache/' . $hash . '/';
+                $pos = strpos($candidatePath, $needle);
+                if ($pos !== false) {
+                    $rel = ltrim(substr($candidatePath, $pos + strlen($needle)), '/');
+                    if ($rel !== '') {
+                        return $rel;
+                    }
+                }
+            }
+
+            if ($trimmed[0] !== '/' && !preg_match('#^[a-zA-Z]:/#', $trimmed) && strpos($trimmed, '://') === false) {
+                $rel = ltrim($trimmed, '/');
                 if ($rel !== '') {
-                    return route('photobook.asset', ['hash' => $hash, 'path' => $rel], false);
+                    return $rel;
                 }
             }
         }
@@ -167,8 +195,21 @@ class PhotobookApiController extends Controller
                         $coverItem = $coverOv['items'][0] ?? null;
                         if (is_array($coverItem)) {
                             // Update cover data from overrides
+                            $existingCoverImage = $data['cover']['image'] ?? null;
+                            if (is_string($existingCoverImage) && $existingCoverImage !== '') {
+                                $normalizedExisting = $this->extractRelativeAssetPath($hash, $existingCoverImage);
+                                if ($normalizedExisting) {
+                                    $data['cover']['image'] = $normalizedExisting;
+                                }
+                            }
                             if (!empty($coverItem['photo']['path'])) {
-                                $data['cover']['image'] = $coverItem['photo']['path'];
+                                $coverPhotoPath = (string) $coverItem['photo']['path'];
+                                $normalizedPhoto = $this->extractRelativeAssetPath($hash, $coverPhotoPath);
+                                if ($normalizedPhoto) {
+                                    $data['cover']['image'] = $normalizedPhoto;
+                                } else {
+                                    $data['cover']['sourcePath'] = $coverPhotoPath;
+                                }
                             }
                             // Add positioning and transformation properties (legacy and canonical)
                             foreach (['objectPosition', 'scale', 'rotate'] as $prop) {
@@ -182,6 +223,16 @@ class PhotobookApiController extends Controller
                                 }
                             }
                             // Add webSrc for cover if we have a path
+                            if (!empty($coverItem['src'])) {
+                                $normalizedFromSrc = $this->extractRelativeAssetPath($hash, $coverItem['src']);
+                                if ($normalizedFromSrc) {
+                                    $data['cover']['image'] = $normalizedFromSrc;
+                                }
+                                $coverWeb = $this->normalizeAssetUrl($hash, $coverItem['src']);
+                                if ($coverWeb) {
+                                    $data['cover']['webSrc'] = $coverWeb;
+                                }
+                            }
                             if (!empty($data['cover']['image'])) {
                                 $coverWeb = $this->normalizeAssetUrl($hash, $data['cover']['image']);
                                 if ($coverWeb) {

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,7 @@ services:
     working_dir: /workspace
     volumes:
       - ./:/workspace:cached
-    command: bash -lc "bash .devcontainer/postCreate.sh && npm run dev:all"
+    command: bash -lc "bash .devcontainer/ensure-node.sh && bash .devcontainer/postCreate.sh && npm run dev:all"
     ports:
       - "8000:8000"
       - "5173:5173"


### PR DESCRIPTION
## Summary
- add a lightweight ensure-node script and run it from docker compose before the devcontainer bootstrap to guarantee npm is available
- teach the photobook API to keep cached cover image paths while still exposing the original source path and normalised web URLs

## Testing
- APP_KEY=$(php -r "echo 'base64:'.base64_encode(random_bytes(32));") composer test

------
https://chatgpt.com/codex/tasks/task_e_68d19c11a3a88322bc8b4ce5d1816eeb