### PR TITLE
Fix photobook gap units for Dompdf

### DIFF
--- a/resources/views/photobook/generic.blade.php
+++ b/resources/views/photobook/generic.blade.php
@@ -19,6 +19,13 @@
       }
       return $str;
   };
+  if (!isset($gapHalfMm)) {
+      $formatMm = static function (float $value): string {
+          $formatted = number_format($value, 6, '.', '');
+          return rtrim(rtrim($formatted, '0'), '.');
+      };
+      $gapHalfMm = $formatMm(((float) config('photobook.page_gap_mm', 2.5)) / 2);
+  }
 @endphp
 <div class="page">
   <div class="page-inner">
@@ -30,7 +37,7 @@
              top:    {{ $s['y'] * 100 }}%;
              width:  calc({{ $s['w'] * 100 }}% - var(--eps-mm));
              height: calc({{ $s['h'] * 100 }}% - var(--eps-mm));
-             padding: calc(var(--gap-mm) / 2);
+             padding: {{ $gapHalfMm }}mm;
            ">
         @php
           $src = $it['src'] ?? ($asset_url ? $asset_url($it['photo']) : '');

--- a/resources/views/photobook/layout.blade.php
+++ b/resources/views/photobook/layout.blade.php
@@ -12,9 +12,19 @@ Create the main layout for the PDF:
 <style>
 @page { margin: {{ (int) config('photobook.margin_mm', 0) }}mm; }
 /* CSS variables for consistent units */
+@php
+    $gapMm = (float) config('photobook.page_gap_mm', 2.5);
+    $gapHalfMm = $gapMm / 2;
+    $formatMm = static function (float $value): string {
+        $formatted = number_format($value, 6, '.', '');
+        return rtrim(rtrim($formatted, '0'), '.');
+    };
+    $gapMmStr = $formatMm($gapMm);
+    $gapHalfMmStr = $formatMm($gapHalfMm);
+@endphp
 :root {
   --frame-mm: {{ (float) config('photobook.page_frame_mm', 6) }}mm;
-  --gap-mm:   {{ (float) config('photobook.page_gap_mm', 2.5) }}mm;
+  --gap-mm:   {{ $gapMmStr }}mm;
   --eps-mm:   0.15mm;
 }
 .page { position: relative; page-break-after: always; }
@@ -33,9 +43,9 @@ Create the main layout for the PDF:
 .slot-inner-legacy { width:100%; height:100%; background-repeat:no-repeat; background-origin: content-box; }
 .caption {
   position:absolute;
-  left: calc(var(--gap-mm) / 2);
-  right: calc(var(--gap-mm) / 2);
-  bottom: calc(var(--gap-mm) / 2);
+  left: {{ $gapHalfMmStr }}mm;
+  right: {{ $gapHalfMmStr }}mm;
+  bottom: {{ $gapHalfMmStr }}mm;
   font-size: 10pt;
   line-height: 1.25;
   padding: 1.4mm 1.8mm;
@@ -55,9 +65,19 @@ Create the main layout for the PDF:
 
 @foreach($pages as $page)
     @if(($page['template'] ?? '') === 'generic')
-        @include('photobook.generic', ['slots' => $page['slots'], 'items' => $page['items'], 'asset_url' => $asset_url])
+        @include('photobook.generic', [
+            'slots' => $page['slots'],
+            'items' => $page['items'],
+            'asset_url' => $asset_url,
+            'gapMm' => $gapMmStr,
+            'gapHalfMm' => $gapHalfMmStr,
+        ])
     @else
-        @include('photobook.page-' . $page['template'], ['photos' => $page['photos']])
+        @include('photobook.page-' . $page['template'], [
+            'photos' => $page['photos'],
+            'gapMm' => $gapMmStr,
+            'gapHalfMm' => $gapHalfMmStr,
+        ])
     @endif
 @endforeach
 

--- a/resources/views/photobook/page-1up.blade.php
+++ b/resources/views/photobook/page-1up.blade.php
@@ -1,6 +1,15 @@
+@php
+  if (!isset($gapHalfMm)) {
+      $formatMm = static function (float $value): string {
+          $formatted = number_format($value, 6, '.', '');
+          return rtrim(rtrim($formatted, '0'), '.');
+      };
+      $gapHalfMm = $formatMm(((float) config('photobook.page_gap_mm', 2.5)) / 2);
+  }
+@endphp
 <div class="page">
   <div class="page-inner">
-    <div class="slot" style="left:0; top:0; width:calc(100% - var(--eps-mm)); height:calc(100% - var(--eps-mm)); padding: calc(var(--gap-mm)/2);">
+    <div class="slot" style="left:0; top:0; width:calc(100% - var(--eps-mm)); height:calc(100% - var(--eps-mm)); padding: {{ $gapHalfMm }}mm;">
       @php
         $src = $asset_url($photos[0]);
         $p = $photos[0] ?? null;

--- a/resources/views/photobook/page-2up.blade.php
+++ b/resources/views/photobook/page-2up.blade.php
@@ -1,3 +1,12 @@
+@php
+  if (!isset($gapHalfMm)) {
+      $formatMm = static function (float $value): string {
+          $formatted = number_format($value, 6, '.', '');
+          return rtrim(rtrim($formatted, '0'), '.');
+      };
+      $gapHalfMm = $formatMm(((float) config('photobook.page_gap_mm', 2.5)) / 2);
+  }
+@endphp
 <div class="page">
   <div class="page-inner">
     {{-- left column --}}
@@ -7,7 +16,7 @@
            top: 0;
            width:  calc(50% - var(--eps-mm));
            height: calc(100% - var(--eps-mm));
-           padding: calc(var(--gap-mm)/2);
+           padding: {{ $gapHalfMm }}mm;
          ">
       @php
         $src = $asset_url($photos[0]);
@@ -34,7 +43,7 @@
            top:  0;
            width:  calc(50% - var(--eps-mm));
            height: calc(100% - var(--eps-mm));
-           padding: calc(var(--gap-mm)/2);
+           padding: {{ $gapHalfMm }}mm;
          ">
       @php
         $src = $asset_url($photos[1]);

--- a/resources/views/photobook/page-3up.blade.php
+++ b/resources/views/photobook/page-3up.blade.php
@@ -1,3 +1,12 @@
+@php
+  if (!isset($gapHalfMm)) {
+      $formatMm = static function (float $value): string {
+          $formatted = number_format($value, 6, '.', '');
+          return rtrim(rtrim($formatted, '0'), '.');
+      };
+      $gapHalfMm = $formatMm(((float) config('photobook.page_gap_mm', 2.5)) / 2);
+  }
+@endphp
 <div class="page">
   <div class="page-inner">
     {{-- col 1 --}}
@@ -7,7 +16,7 @@
            top:  0;
            width:  calc(33.3334% - var(--eps-mm));
            height: calc(100% - var(--eps-mm));
-           padding: calc(var(--gap-mm)/2);
+           padding: {{ $gapHalfMm }}mm;
          ">
       @php
         $src = $asset_url($photos[0]);
@@ -34,7 +43,7 @@
            top:  0;
            width:  calc(33.3333% - var(--eps-mm));
            height: calc(100% - var(--eps-mm));
-           padding: calc(var(--gap-mm)/2);
+           padding: {{ $gapHalfMm }}mm;
          ">
       @php
         $src = $asset_url($photos[1]);
@@ -61,7 +70,7 @@
            top:  0;
            width:  calc(33.3333% - var(--eps-mm));
            height: calc(100% - var(--eps-mm));
-           padding: calc(var(--gap-mm)/2);
+           padding: {{ $gapHalfMm }}mm;
          ">
       @php
         $src = $asset_url($photos[2]);


### PR DESCRIPTION
## Summary
- compute the photobook gap in PHP within the layout so captions use numeric millimeter offsets
- pass the preformatted gap measurements to the page partials and replace inline calc() padding with direct mm values
- render a sample photobook PDF to confirm captions draw above the images with the adjusted spacing

## Testing
- php artisan test
- php /tmp/render-sample.php

------
https://chatgpt.com/codex/tasks/task_e_68d1a6b2abe8832290c70f51814b8b90