### PR TITLE
Refactor photobook domain normalizers

### DIFF
--- a/resources/photobook-editor/src/features/photobook/model/photobook.normalizers.ts
+++ b/resources/photobook-editor/src/features/photobook/model/photobook.normalizers.ts
@@ -1,0 +1,154 @@
+import type { FitMode, PhotobookItem, PhotobookPage, SlotRect, Vec2 } from './photobook.types';
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export function isPositiveFinite(value: unknown): boolean {
+  return Number.isFinite(Number(value)) && Number(value) > 0;
+}
+
+export function normalizeFit(value?: unknown, fallback?: unknown): FitMode {
+  return value === 'contain' || fallback === 'contain' ? 'contain' : 'cover';
+}
+
+export function alignFromObjectPosition(objectPosition?: string | null): Vec2 {
+  if (!objectPosition) return { x: 0, y: 0 };
+
+  const parts = String(objectPosition).trim().split(/\s+/, 2);
+  const px = Number((parts[0] || '').replace('%', ''));
+  const py = Number((parts[1] || '').replace('%', ''));
+
+  if (!Number.isFinite(px) || !Number.isFinite(py)) {
+    return { x: 0, y: 0 };
+  }
+
+  return {
+    x: clamp((px - 50) / 50, -1, 1),
+    y: clamp((py - 50) / 50, -1, 1),
+  };
+}
+
+export function normalizeAlign(rawAlign?: unknown, objectPosition?: string | null): Vec2 {
+  if (rawAlign && typeof rawAlign === 'object') {
+    const align = rawAlign as Partial<Vec2>;
+
+    return {
+      x: clamp(Number(align.x ?? 0), -1, 1),
+      y: clamp(Number(align.y ?? 0), -1, 1),
+    };
+  }
+
+  return alignFromObjectPosition(objectPosition);
+}
+
+export function normalizeOffset(rawOffset?: unknown): Vec2 {
+  if (!rawOffset || typeof rawOffset !== 'object') {
+    return { x: 0, y: 0 };
+  }
+
+  const offset = rawOffset as Partial<Vec2>;
+
+  return {
+    x: Number.isFinite(Number(offset.x)) ? Number(offset.x) : 0,
+    y: Number.isFinite(Number(offset.y)) ? Number(offset.y) : 0,
+  };
+}
+
+export function objectPositionFromAlign(align?: Vec2 | null): string {
+  const x = clamp(Number(align?.x ?? 0), -1, 1);
+  const y = clamp(Number(align?.y ?? 0), -1, 1);
+
+  return `${Math.round(50 + x * 50)}% ${Math.round(50 + y * 50)}%`;
+}
+
+export function normalizeZoom(zoom?: unknown, scale?: unknown): number {
+  if (isPositiveFinite(zoom)) return Number(zoom);
+  if (isPositiveFinite(scale)) return Number(scale);
+
+  return 1;
+}
+
+export function normalizeRotation(rotation?: unknown, rotate?: unknown): number {
+  if (Number.isFinite(Number(rotation))) return Number(rotation);
+  if (Number.isFinite(Number(rotate))) return Number(rotate);
+
+  return 0;
+}
+
+export function normalizeCaption(caption?: unknown): string | undefined {
+  if (typeof caption === 'string') return caption;
+  if (typeof caption === 'number') return String(caption);
+
+  return undefined;
+}
+
+export function normalizeSlot(slot: unknown): SlotRect {
+  const raw = slot && typeof slot === 'object' ? slot as Partial<SlotRect> : {};
+  const ar = raw.ar ?? null;
+
+  return {
+    x: Number(raw.x ?? 0),
+    y: Number(raw.y ?? 0),
+    w: Number(raw.w ?? 1),
+    h: Number(raw.h ?? 1),
+    ...(ar ? { ar } : {}),
+  };
+}
+
+export function normalizePhotobookItem(raw: any): PhotobookItem {
+  const fit = normalizeFit(raw?.fit, raw?.crop);
+  const align = normalizeAlign(raw?.align, raw?.objectPosition);
+  const offset = normalizeOffset(raw?.offset);
+  const zoom = normalizeZoom(raw?.zoom, raw?.scale);
+  const rotation = normalizeRotation(raw?.rotation, raw?.rotate);
+  const caption = normalizeCaption(raw?.caption);
+
+  return {
+    id: raw?.id,
+    slotIndex: Number.isFinite(Number(raw?.slotIndex)) ? Number(raw.slotIndex) : 0,
+
+    photo: raw?.photo ?? null,
+    src: raw?.webSrc ?? raw?.web ?? raw?.src ?? null,
+    web: raw?.web ?? null,
+    webSrc: raw?.webSrc ?? null,
+
+    fit,
+    align,
+    offset,
+    zoom,
+    rotation,
+    auto: raw?.auto === true,
+
+    crop: fit,
+    objectPosition: raw?.objectPosition ?? objectPositionFromAlign(align),
+    scale: zoom,
+    rotate: rotation,
+
+    x: raw?.x,
+    y: raw?.y,
+    width: raw?.width,
+    height: raw?.height,
+
+    caption,
+
+    _iw: raw?._iw,
+    _ih: raw?._ih,
+    _error: raw?._error,
+  };
+}
+
+export function normalizePhotobookPage(raw: any, index: number): PhotobookPage {
+  const n = typeof raw?.n === 'number' ? raw.n : index + 1;
+  const id = String(raw?.id ?? `n-${n}`);
+
+  return {
+    id,
+    n,
+    templateId: raw?.templateId ?? raw?.template ?? undefined,
+    template: raw?.template ?? undefined,
+    slots: Array.isArray(raw?.slots) ? raw.slots.map(normalizeSlot) : [],
+    items: Array.isArray(raw?.items) ? raw.items.map(normalizePhotobookItem) : [],
+    layoutFeedback: raw?.layoutFeedback ?? null,
+  };
+}

--- a/resources/photobook-editor/src/features/photobook/model/photobook.types.ts
+++ b/resources/photobook-editor/src/features/photobook/model/photobook.types.ts
@@ -1,0 +1,81 @@
+export type FitMode = 'cover' | 'contain';
+
+export type Vec2 = {
+  x: number;
+  y: number;
+};
+
+export type PhotoRef = {
+  path: string;
+  filename?: string;
+  width?: number | null;
+  height?: number | null;
+  ratio?: number | null;
+  takenAt?: string | null;
+};
+
+export type SlotRect = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  ar?: number | null;
+};
+
+export type LayoutFeedback = {
+  preferred?: boolean;
+  templateId?: string | null;
+  reason?: string | null;
+  updated_at?: string;
+} | null;
+
+export type PhotobookItem = {
+  id?: string | number;
+  slotIndex: number;
+
+  photo?: PhotoRef | null;
+
+  src?: string | null;
+  web?: string | null;
+  webSrc?: string | null;
+
+  fit?: FitMode;
+  align?: Vec2;
+  offset?: Vec2;
+  zoom?: number;
+  rotation?: number;
+  auto?: boolean;
+
+  objectPosition?: string;
+  crop?: FitMode;
+  scale?: number;
+  rotate?: number;
+
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+
+  caption?: string;
+
+  _iw?: number;
+  _ih?: number;
+  _error?: boolean;
+};
+
+export type PhotobookPage = {
+  id: string;
+  n?: number;
+  templateId?: string | null;
+  template?: string | null;
+  slots?: SlotRect[];
+  items: PhotobookItem[];
+  layoutFeedback?: LayoutFeedback;
+};
+
+export type AlbumRecord = {
+  hash: string;
+  folder: string;
+  count: number;
+  created_at: string;
+};

--- a/resources/photobook-editor/src/store/photobook.ts
+++ b/resources/photobook-editor/src/store/photobook.ts
@@ -1,72 +1,12 @@
 import { create } from 'zustand';
-import type { RenderSpec } from '../types/photobook';
-
-type Fit = 'cover' | 'contain';
-
-type Align = {
-  x: number;
-  y: number;
-};
-
-type Offset = {
-  x: number;
-  y: number;
-}
+import type { PhotobookItem as Item, PhotobookPage as Page, SlotRect } from '../features/photobook/model/photobook.types';
+import { normalizePhotobookItem, normalizePhotobookPage, normalizeSlot } from '../features/photobook/model/photobook.normalizers';
 
 type UserCropSpec = {
   alignX: number;
   alignY: number;
   zoom: number;
   rotation: number;
-};
-
-type Item = {
-  id?: string | number;
-  slotIndex: number;
-
-  photo?: any;
-
-  src?: string | null;
-
-  web?: string | null;
-  webSrc?: string | null;
-
-  fit?: Fit;
-  align?: Align;
-  offset?: Offset;
-  zoom?: number;
-  rotation?: number;
-  auto?: boolean;
-
-  objectPosition?: string;
-  crop?: Fit;
-  scale?: number;
-  rotate?: number;
-
-  x?: number;
-  y?: number;
-  width?: number;
-  height?: number;
-
-  caption?: string;
-
-  _iw?: number;
-  _ih?: number;
-  _error?: boolean;
-}
-
-type Page = {
-  id: string;        // stable id for local edits
-  n?: number;        // 1-based page number from server, if present
-  templateId?: string;
-  slots?: { x: number; y: number; w: number; h: number; ar?: number | null }[];
-  items: Item[];
-  layoutFeedback?: {
-    preferred?: boolean;
-    templateId?: string | null;
-    reason?: string | null;
-    updated_at?: string;
-  } | null;
 };
 
 type PBState = {
@@ -81,11 +21,7 @@ type PBState = {
   updateItemWith: (pageId: string, idx: number, updater: (item: Item) => Item) => void;
   replacePageItems: (pageId: string, items: Item[]) => void;
   swapItems: (pageId: string, from: number, to: number) => void;
-  updateTemplate: (
-    pageId: string,
-    templateId: string,
-    slots?: { x: number; y: number; w: number; h: number; ar?: number | null }[]
-  ) => void;
+  updateTemplate: (pageId: string, templateId: string, slots?: SlotRect[]) => void;
 
   commitUserCrop: (pageId: string, idx: number, spec: UserCropSpec) => void;
   updatePageFeedback: (pageId: string, feedback: Page['layoutFeedback']) => void;
@@ -96,102 +32,6 @@ type PBState = {
   redo: () => void;
 };
 
-function clamp(value: number, min: number, max: number) {
-  return Math.max(Math.min(value, max), min);
-}
-
-function alignFromObjectPosition(objectPosition?: string): Align {
-  if (!objectPosition) return { x: 0, y: 0 };
-
-  const parts = String(objectPosition).trim().split(/\s+/, 2);
-  const px = Number((parts[0] || '').replace('%', ''));
-  const py = Number((parts[1] || '').replace('%', ''));
-
-  if (!Number.isFinite(px) || !Number.isFinite(py)) {
-    return { x: 0, y: 0 };
-  }
-
-  return {
-    x: clamp((px - 50) / 50, -1, 1),
-    y: clamp((py - 50) / 50, -1, 1),
-  };
-}
-
-function objectPositionFromAlign(align?: Align) {
-  const x = clamp(Number(align?.x ?? 0), -1, 1);
-  const y = clamp(Number(align?.y ?? 0), -1, 1);
-
-  return `${Math.round(50 + x * 50)}% ${Math.round(50 + y * 50)}%`;
-}
-
-function normalizeItem(it: any): Item {
-  const fit: Fit = it.fit === 'contain' || it.crop === 'contain'
-    ? 'contain'
-    : 'cover';
-
-  const align = it.align && typeof it.align === 'object'
-    ? {
-      x: clamp(Number(it.align.x ?? 0), -1, 1),
-      y: clamp(Number(it.align.y ?? 0), -1, 1),
-    }
-    : alignFromObjectPosition(it.objectPosition);
-
-  const offset = it.offset && typeof it.offset === 'object'
-    ? {
-      x: Number.isFinite(Number(it.offset.x)) ? Number(it.offset.x) : 0,
-      y: Number.isFinite(Number(it.offset.y)) ? Number(it.offset.y) : 0,
-    }
-    : { x: 0, y: 0 };
-
-  const zoom = Number.isFinite(Number(it.zoom)) && Number(it.zoom) > 0
-    ? Number(it.zoom)
-    : Number.isFinite(Number(it.scale)) && Number(it.scale) > 0
-      ? Number(it.scale)
-      : 1;
-
-  const rotation = Number.isFinite(Number(it.rotation))
-    ? Number(it.rotation)
-    : Number.isFinite(Number(it.rotate))
-      ? Number(it.rotate)
-      : 0;
-
-  const caption =
-    typeof it.caption === 'string'
-      ? it.caption
-      : typeof it.caption === 'number'
-        ? String(it.caption)
-        : undefined;
-
-  return {
-    id: it.id,
-    slotIndex: Number.isFinite(Number(it.slotIndex)) ? Number(it.slotIndex) : 0,
-
-    photo: it.photo,
-    src: it.webSrc ?? it.web ?? it.src ?? null,
-    web: it.web ?? null,
-    webSrc: it.webSrc ?? null,
-
-    fit,
-    align,
-    offset,
-    zoom,
-    rotation,
-    auto: it.auto === true,
-
-    crop: fit,
-    objectPosition: it.objectPosition ?? objectPositionFromAlign(align),
-    scale: zoom,
-    rotate: rotation,
-
-    x: it.x,
-    y: it.y,
-    width: it.width,
-    height: it.height,
-
-    caption,
-  };
-}
-
 export const usePB = create<PBState>((set, get) => ({
   hash: '',
   pages: [],
@@ -199,15 +39,7 @@ export const usePB = create<PBState>((set, get) => ({
   future: [],
   setInitial: (hash, pages) => set({
     hash,
-    pages: (pages || []).map((p: any, idx: number) => ({
-      id: String(p.id ?? `n-${p.n ?? (idx + 1)}`),
-      n: typeof p.n === 'number' ? p.n : (idx + 1),
-      templateId: p.templateId ?? p.template ?? undefined,
-      slots: Array.isArray(p.slots) ? p.slots.map((s: any) => ({
-        x: Number(s.x ?? 0), y: Number(s.y ?? 0), w: Number(s.w ?? 1), h: Number(s.h ?? 1), ar: s.ar ?? null
-      })) : [],
-      items: (p.items || []).map(normalizeItem),
-    })),
+    pages: (pages || []).map(normalizePhotobookPage),
     past: [],
     future: [],
   }),
@@ -222,7 +54,7 @@ export const usePB = create<PBState>((set, get) => ({
         items: page.items.map((item, itemIdx) => {
           if (itemIdx !== idx) return item;
 
-          return normalizeItem({
+          return normalizePhotobookItem({
             ...item,
             ...changes,
             auto: false,
@@ -248,7 +80,7 @@ export const usePB = create<PBState>((set, get) => ({
         items: page.items.map((item, itemIdx) => {
           if (itemIdx !== idx) return item;
 
-          return normalizeItem({
+          return normalizePhotobookItem({
             ...item,
             align: {
               x: spec.alignX,
@@ -270,7 +102,7 @@ export const usePB = create<PBState>((set, get) => ({
   },
   addPageLocal: (page) => {
     const { pages, past } = get();
-    set({ pages: [...pages, page], past: [...past, pages], future: [] });
+    set({ pages: [...pages, normalizePhotobookPage(page, pages.length)], past: [...past, pages], future: [] });
   },
   deletePageLocal: (pageId) => {
     const { pages, past } = get();
@@ -299,7 +131,7 @@ export const usePB = create<PBState>((set, get) => ({
         items: page.items.map((item, itemIdx) => {
           if (itemIdx !== idx) return item;
 
-          return normalizeItem({
+          return normalizePhotobookItem({
             ...updater({ ...item }),
             auto: false,
           });
@@ -322,7 +154,7 @@ export const usePB = create<PBState>((set, get) => ({
 
       return {
         ...page,
-        items: items.map(normalizeItem),
+        items: items.map(normalizePhotobookItem),
       };
     });
 
@@ -349,7 +181,7 @@ export const usePB = create<PBState>((set, get) => ({
       return {
         ...page,
         items: items.map((item, index) =>
-          normalizeItem({
+          normalizePhotobookItem({
             ...item,
             slotIndex: index,
             auto: false,
@@ -374,19 +206,9 @@ export const usePB = create<PBState>((set, get) => ({
       return {
         ...page,
         templateId,
-        ...(slots
-          ? {
-            slots: slots.map((slot) => ({
-              x: Number(slot.x ?? 0),
-              y: Number(slot.y ?? 0),
-              w: Number(slot.w ?? 1),
-              h: Number(slot.h ?? 1),
-              ...(slot.ar ? { ar: slot.ar } : {}),
-            })),
-          }
-          : {}),
+        ...(slots ? { slots: slots.map(normalizeSlot) } : {}),
         items: page.items.map((item, index) =>
-          normalizeItem({
+          normalizePhotobookItem({
             ...item,
             slotIndex: index,
             auto: false,
@@ -414,4 +236,3 @@ export const usePB = create<PBState>((set, get) => ({
     set({ pages: next });
   },
 }));
-


### PR DESCRIPTION
## Summary
- add shared photobook domain types under `features/photobook/model`
- add shared normalizers for fit, align, offset, zoom, rotation, caption, slots, items and pages
- replace duplicated Zustand store normalization with the shared normalizers

## Notes
- intentionally keeps the first refactor small: no UI or canvas behavior changes yet
- this prepares the next step: moving `App.tsx` and `EditorCanvas.tsx` normalization/persistence into shared domain utilities

## Verification
- reviewed repository diff
- no package script for typecheck exists; `package.json` currently exposes `build`, `dev`, and `dev:all` only