### PR TITLE
Extract shared photobook serializers

### DIFF
--- a/resources/photobook-editor/src/components/EditorCanvas.tsx
+++ b/resources/photobook-editor/src/components/EditorCanvas.tsx
@@ -5,6 +5,7 @@ import { fitMath, alignOffsetToPanPx, solveAlignOffset, clamp, isFinitePos } fro
 import { Badge } from './ui/badge';
 import { Button } from './ui/button';
 import { normalizePhotobookItem } from '../features/photobook/model/photobook.normalizers';
+import { buildOverridesPayload, serializeItemsForLegacySave } from '../features/photobook/model/photobook.serializers';
 
 /* =========================================================
    useUndoRedo (inline) – batching & limits
@@ -171,62 +172,6 @@ function validateItem(it: AnyItem): string[] {
   if (!Number.isFinite(it.rotation)) errs.push('rotation');
   if (it.photo && typeof it.photo.path !== 'string') errs.push('photo.path');
   return errs;
-}
-
-function buildOverridesPayload(
-  pageNumber: number,
-  templateId: string | undefined,
-  items: AnyItem[]
-) {
-  const pageKey = String(pageNumber);
-  const normalized = items.map(normalizeItem);
-
-  const itemsOut = normalized
-    .slice()
-    .sort((a, b) => a.slotIndex - b.slotIndex)
-    .map(it => {
-      const fit: Fit = it.fit === 'contain' ? 'contain' : 'cover';
-      const align = { x: clamp(Number(it.align?.x ?? 0), -1, 1), y: clamp(Number(it.align?.y ?? 0), -1, 1) };
-      const offset = { x: Number(it.offset?.x) || 0, y: Number(it.offset?.y) || 0 };
-      const zoom = isFinitePos(it.zoom) ? Number(it.zoom) : 1;
-      const rotation = Number.isFinite(Number(it.rotation)) ? ((Number(it.rotation) % 360) + 360) % 360 : 0;
-      const caption =
-        typeof it.caption === 'string'
-          ? it.caption
-          : typeof (it as any).caption === 'number'
-            ? String((it as any).caption)
-            : undefined;
-
-      const canon = {
-        slotIndex: it.slotIndex,
-        fit, align, offset, zoom, rotation,
-        auto: it.auto === true,
-        ...(it.photo?.path ? { photo: { path: it.photo.path, ...(it.photo.filename ? { filename: it.photo.filename } : {}) } } : {}),
-        ...(caption !== undefined ? { caption } : {}),
-      };
-
-      const legacy = {
-        crop: fit,
-        objectPosition: `${Math.round(50 + align.x * 50)}% ${Math.round(50 + align.y * 50)}%`,
-        scale: zoom,
-        rotate: rotation,
-      };
-
-      const maybeSrc = (it as any).web ?? (it as any).webSrc ?? (it as any).src
-        ? { src: (it as any).web ?? (it as any).webSrc ?? (it as any).src }
-        : {};
-
-      return { ...canon, ...legacy, ...maybeSrc };
-    });
-
-  return {
-    pages: {
-      [String(pageNumber)]: {
-        ...(templateId ? { templateId } : {}), // include if set
-        items: itemsOut,
-      },
-    },
-  };
 }
 
 async function postOverrides(saveUrl: string, payload: any, init?: Omit<RequestInit, 'method' | 'body'>) {
@@ -400,7 +345,7 @@ export default function EditorCanvas({
       }
     }, 800);
     return () => clearTimeout(t);
-  }, [items, page.n, saveUrl, saveFetchInit]);
+  }, [items, page.n, page.templateId, saveUrl, saveFetchInit]);
 
   // Manueller Save
   const handleSave = useCallback(async () => {
@@ -412,20 +357,7 @@ export default function EditorCanvas({
 
     // Optional: keep legacy callback for older listeners
     if (onSave) {
-      const legacyItems = normalized.map(it => {
-        const ax = clamp(it.align?.x ?? 0, -1, 1);
-        const ay = clamp(it.align?.y ?? 0, -1, 1);
-        return {
-          slotIndex: it.slotIndex,
-          crop: (it.fit === 'contain' ? 'contain' : 'cover'),
-          objectPosition: `${Math.round(50 + ax * 50)}% ${Math.round(50 + ay * 50)}%`,
-          scale: isFinitePos(it.zoom) ? Number(it.zoom) : 1,
-          rotate: Number.isFinite(Number(it.rotation)) ? Number(it.rotation) : 0,
-          photo: it.photo ? { path: it.photo.path, ...(it.photo.filename ? { filename: it.photo.filename } : {}) } : null,
-          src: (it as any).web ?? (it as any).webSrc ?? (it as any).src ?? null,
-        };
-      });
-      onSave(legacyItems as any);
+      onSave(serializeItemsForLegacySave(normalized) as any);
     }
 
     if (saveUrl) {
@@ -440,7 +372,7 @@ export default function EditorCanvas({
     console.error(e);
     setSaveState('error');
   }
-}, [items, onSave, page.n, saveUrl, saveFetchInit]);
+}, [items, onSave, page.n, page.templateId, saveUrl, saveFetchInit]);
 
   // Keyboard Shortcuts & Nudge & Undo/Redo
   useEffect(() => {

--- a/resources/photobook-editor/src/features/photobook/model/photobook.serializers.ts
+++ b/resources/photobook-editor/src/features/photobook/model/photobook.serializers.ts
@@ -1,0 +1,118 @@
+import type { PhotobookItem, PhotobookPage } from './photobook.types';
+import { clamp, normalizePhotobookItem, objectPositionFromAlign } from './photobook.normalizers';
+
+export function serializeItemForPagesJson(rawItem: unknown) {
+  const item = normalizePhotobookItem(rawItem);
+  const fit = item.fit === 'contain' ? 'contain' : 'cover';
+  const align = {
+    x: clamp(Number(item.align?.x ?? 0), -1, 1),
+    y: clamp(Number(item.align?.y ?? 0), -1, 1),
+  };
+  const offset = {
+    x: Number.isFinite(Number(item.offset?.x)) ? Number(item.offset?.x) : 0,
+    y: Number.isFinite(Number(item.offset?.y)) ? Number(item.offset?.y) : 0,
+  };
+  const zoom = Number.isFinite(Number(item.zoom)) && Number(item.zoom) > 0 ? Number(item.zoom) : 1;
+  const rotation = Number.isFinite(Number(item.rotation))
+    ? ((Number(item.rotation) % 360) + 360) % 360
+    : 0;
+  const caption =
+    typeof item.caption === 'string'
+      ? item.caption
+      : typeof (item as any).caption === 'number'
+        ? String((item as any).caption)
+        : undefined;
+  const src = (item as any).web ?? (item as any).webSrc ?? (item as any).src ?? null;
+
+  return {
+    slotIndex: item.slotIndex,
+    fit,
+    align,
+    offset,
+    zoom,
+    rotation,
+    auto: item.auto === true,
+    ...(item.photo?.path
+      ? {
+          photo: {
+            path: item.photo.path,
+            ...(item.photo.filename ? { filename: item.photo.filename } : {}),
+          },
+        }
+      : {}),
+    ...(caption !== undefined ? { caption } : {}),
+    crop: fit,
+    objectPosition: objectPositionFromAlign(align),
+    scale: zoom,
+    rotate: rotation,
+    ...(src ? { src } : {}),
+  };
+}
+
+export function serializeItemsForPagesJson(items: unknown[]) {
+  return items
+    .map(normalizePhotobookItem)
+    .slice()
+    .sort((a, b) => a.slotIndex - b.slotIndex)
+    .map(serializeItemForPagesJson);
+}
+
+export function serializeItemsForLegacySave(items: unknown[]) {
+  return items.map((rawItem) => {
+    const item = normalizePhotobookItem(rawItem);
+    const align = {
+      x: clamp(Number(item.align?.x ?? 0), -1, 1),
+      y: clamp(Number(item.align?.y ?? 0), -1, 1),
+    };
+    const fit = item.fit === 'contain' ? 'contain' : 'cover';
+    const zoom = Number.isFinite(Number(item.zoom)) && Number(item.zoom) > 0 ? Number(item.zoom) : 1;
+    const rotation = Number.isFinite(Number(item.rotation)) ? Number(item.rotation) : 0;
+    const src = (item as any).web ?? (item as any).webSrc ?? (item as any).src ?? null;
+
+    return {
+      slotIndex: item.slotIndex,
+      crop: fit,
+      objectPosition: objectPositionFromAlign(align),
+      scale: zoom,
+      rotate: rotation,
+      photo: item.photo?.path
+        ? {
+            path: item.photo.path,
+            ...(item.photo.filename ? { filename: item.photo.filename } : {}),
+          }
+        : null,
+      src,
+    };
+  });
+}
+
+export function buildOverridesPayload(
+  pageNumber: number,
+  templateId: string | undefined | null,
+  items: unknown[],
+) {
+  return {
+    pages: {
+      [String(pageNumber)]: {
+        ...(templateId ? { templateId } : {}),
+        items: serializeItemsForPagesJson(items),
+      },
+    },
+  };
+}
+
+export function serializePageForSave(rawPage: PhotobookPage | any, itemsOverride?: unknown[]) {
+  const isCover = rawPage?.id === 'cover' || rawPage?.templateId === 'cover' || rawPage?.template === 'cover';
+  const n = isCover ? 0 : Math.max(1, Number(rawPage?.n || 1));
+  const items = Array.isArray(itemsOverride) ? itemsOverride : Array.isArray(rawPage?.items) ? rawPage.items : [];
+
+  return {
+    ...rawPage,
+    id: isCover ? 'cover' : String(rawPage?.id || `page-${n}`),
+    n,
+    templateId: isCover ? 'cover' : (rawPage?.templateId || rawPage?.template || null),
+    slots: Array.isArray(rawPage?.slots) ? rawPage.slots : [],
+    items: items.map(serializeItemForPagesJson),
+    ...(rawPage?.layoutFeedback ? { layoutFeedback: rawPage.layoutFeedback } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- add shared serializers for pages.json-compatible item output
- add shared override payload builder for EditorCanvas autosave payloads
- add shared page serializer for later App/page persistence cleanup
- update `EditorCanvas.tsx` to use `buildOverridesPayload` and `serializeItemsForLegacySave`
- remove the local duplicated override payload construction from `EditorCanvas.tsx`

## Refactor impact
This moves save-payload shaping into the photobook domain layer. `EditorCanvas` now validates and triggers saves, but no longer knows how to manually assemble canonical + legacy payload fields.

## Verification
- reviewed diff against `main`
- changed files: `photobook.serializers.ts`, `EditorCanvas.tsx`
- diff removes 72 lines from `EditorCanvas.tsx` and adds the shared serializer module
- no local build was run in this environment