### PR TITLE
Extract App-level photobook hooks

### DIFF
--- a/resources/photobook-editor/src/features/photobook/hooks/useAlbumSelection.ts
+++ b/resources/photobook-editor/src/features/photobook/hooks/useAlbumSelection.ts
@@ -1,0 +1,61 @@
+import { useEffect, useMemo, useState } from 'react';
+import { PB } from '../../../lib/api';
+import type { AlbumRecord } from '../model/photobook.types';
+
+export const isAlbumHash = (value?: string | null) => /^[a-f0-9]{40}$/i.test(value || '');
+
+export const albumMatchesKey = (album: AlbumRecord, key: string) => {
+  if (!key) return false;
+  return album.hash === key || album.folder === key;
+};
+
+export const albumPrimaryKey = (album: AlbumRecord) => album.folder || album.hash;
+
+export function useAlbumSelection(initialAlbumKey = '') {
+  const [folder, setFolder] = useState(initialAlbumKey);
+  const [albums, setAlbums] = useState<AlbumRecord[]>([]);
+
+  const refreshAlbums = async () => {
+    const response = await PB.getAlbums();
+    const nextAlbums = response?.albums || [];
+    setAlbums(nextAlbums);
+    return nextAlbums;
+  };
+
+  useEffect(() => {
+    refreshAlbums().catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (albums.length === 0) return;
+    const matched = albums.find((album) => albumMatchesKey(album, folder));
+    if (matched && isAlbumHash(folder) && matched.folder) {
+      setFolder(matched.folder);
+      return;
+    }
+    if (!folder) {
+      const first = albums[0];
+      if (first) setFolder(albumPrimaryKey(first));
+    }
+  }, [albums, folder]);
+
+  const currentAlbum = useMemo(
+    () => albums.find((album) => albumMatchesKey(album, folder)) || null,
+    [albums, folder],
+  );
+
+  const albumHash = currentAlbum?.hash || (isAlbumHash(folder) ? folder : '');
+  const albumFolder = currentAlbum?.folder || (!isAlbumHash(folder) ? folder : '');
+  const pagesKey = albumHash || (isAlbumHash(folder) ? folder : '');
+
+  return {
+    folder,
+    setFolder,
+    albums,
+    refreshAlbums,
+    currentAlbum,
+    albumHash,
+    albumFolder,
+    pagesKey,
+  };
+}

--- a/resources/photobook-editor/src/features/photobook/hooks/usePagePersistence.ts
+++ b/resources/photobook-editor/src/features/photobook/hooks/usePagePersistence.ts
@@ -1,0 +1,22 @@
+import { useCallback } from 'react';
+import { PB } from '../../../lib/api';
+import { serializePageForSave } from '../model/photobook.serializers';
+
+export type PersistWithStatus = (task: () => Promise<any>) => Promise<any>;
+
+type UsePagePersistenceArgs = {
+  albumHash: string;
+  persistWithStatus: PersistWithStatus;
+};
+
+export function usePagePersistence({ albumHash, persistWithStatus }: UsePagePersistenceArgs) {
+  const persistPage = useCallback(async (target: any, itemsOverride?: any[]) => {
+    if (!albumHash || !target) throw new Error('Album hash is not ready yet.');
+    const payload = serializePageForSave(target, itemsOverride);
+    await persistWithStatus(() => PB.savePage(albumHash, payload));
+  }, [albumHash, persistWithStatus]);
+
+  return {
+    persistPage,
+  };
+}

--- a/resources/photobook-editor/src/features/photobook/hooks/usePdfExport.ts
+++ b/resources/photobook-editor/src/features/photobook/hooks/usePdfExport.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+import { PB } from '../../../lib/api';
+
+export function usePdfExport(albumHash: string) {
+  const [latestPdfUrl, setLatestPdfUrl] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const handleExportPdf = useCallback(async () => {
+    if (!albumHash) return;
+    setIsExporting(true);
+    setExportError(null);
+
+    try {
+      const response = await PB.exportPdf(albumHash);
+      if (response.ok && response.url) {
+        setLatestPdfUrl(response.url);
+        return;
+      }
+
+      setExportError(response.error || 'Export failed');
+    } catch (error) {
+      setExportError(error instanceof Error ? error.message : 'Export failed');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [albumHash]);
+
+  return {
+    latestPdfUrl,
+    setLatestPdfUrl,
+    isExporting,
+    exportError,
+    handleExportPdf,
+  };
+}

--- a/resources/photobook-editor/src/features/photobook/hooks/useSaveStatus.ts
+++ b/resources/photobook-editor/src/features/photobook/hooks/useSaveStatus.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export type SaveStatus = 'idle' | 'dirty' | 'saving' | 'saved' | 'error';
+
+export function useSaveStatus() {
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
+  const saveStatusTimer = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (saveStatusTimer.current) window.clearTimeout(saveStatusTimer.current);
+  }, []);
+
+  const setSavedSoon = useCallback(() => {
+    if (saveStatusTimer.current) window.clearTimeout(saveStatusTimer.current);
+    setSaveStatus('saved');
+    saveStatusTimer.current = window.setTimeout(() => setSaveStatus('idle'), 1400);
+  }, []);
+
+  const persistWithStatus = useCallback(async (task: () => Promise<any>) => {
+    if (saveStatusTimer.current) window.clearTimeout(saveStatusTimer.current);
+    setSaveStatus('saving');
+    try {
+      const result = await task();
+      setSavedSoon();
+      return result;
+    } catch (error) {
+      setSaveStatus('error');
+      throw error;
+    }
+  }, [setSavedSoon]);
+
+  return {
+    saveStatus,
+    setSaveStatus,
+    setSavedSoon,
+    persistWithStatus,
+  };
+}

--- a/resources/photobook-editor/src/features/photobook/model/assetUrls.ts
+++ b/resources/photobook-editor/src/features/photobook/model/assetUrls.ts
@@ -1,0 +1,29 @@
+export function normalizeAssetRel(value?: string | null): string | null {
+  if (!value) return null;
+  const cleaned = String(value).trim().replace(/\\/g, '/').replace(/^\/+/, '');
+  return cleaned || null;
+}
+
+export function filePathToAssetUrl(path?: string | null): string | null {
+  if (!path) return null;
+  const norm = String(path).replace(/^[a-z]+:\/\//i, '').replace(/\\/g, '/');
+  const match = norm.match(/\/_cache\/([^/]+)\/(.+)$/);
+  if (!match) return null;
+  const hash = match[1];
+  const rel = match[2];
+  const encodedRel = rel.split('/').map(encodeURIComponent).join('/');
+  return `/photobook/asset/${encodeURIComponent(hash)}/${encodedRel}`;
+}
+
+export function webAssetRelFromUrl(url?: string | null): string | null {
+  if (!url) return null;
+  const match = String(url).match(/\/photobook\/asset\/[^/]+\/(.+)$/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export function relAssetUrl(hash: string, rel?: string | null): string | null {
+  const normalizedRel = normalizeAssetRel(rel);
+  if (!hash || !normalizedRel) return null;
+  const encodedRel = normalizedRel.split('/').map(encodeURIComponent).join('/');
+  return `/photobook/asset/${encodeURIComponent(hash)}/${encodedRel}`;
+}


### PR DESCRIPTION
## Summary
- add `useAlbumSelection` for album list loading, hash/folder matching and pages key derivation
- add `useSaveStatus` for dirty/saving/saved/error state and persist-with-status handling
- add `usePagePersistence` using the shared `serializePageForSave` serializer
- add `usePdfExport` for PDF export state and action handling
- add shared asset URL helpers in `assetUrls.ts`

## Refactor impact
This prepares the larger `App.tsx` split by moving cohesive behavior into feature-level hooks/utilities. The current PR adds the target modules without rewiring `App.tsx` yet, so runtime behavior stays unchanged.

## Next step
- wire `App.tsx` to `useAlbumSelection`
- wire `App.tsx` to `useSaveStatus`
- wire `App.tsx` to `usePagePersistence`
- wire `App.tsx` to `usePdfExport`
- replace local asset helper functions with `assetUrls.ts`
- then extract cover state/persistence

## Verification
- reviewed diff against `main`
- changed files: 5 added modules
- no local build was run in this environment